### PR TITLE
Refactor FastAPI app into modular components

### DIFF
--- a/backend/app/logic.py
+++ b/backend/app/logic.py
@@ -1,0 +1,11 @@
+from typing import Dict
+
+
+async def get_root_message() -> Dict[str, str]:
+    """Return a welcome message for the API root endpoint."""
+    return {"message": "Hello from CodeWorld FastAPI"}
+
+
+async def get_health_status() -> Dict[str, str]:
+    """Return the service health status."""
+    return {"status": "ok"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,11 @@
+import uvicorn
 from fastapi import FastAPI
 
+from .routes import router
+
 app = FastAPI()
+app.include_router(router)
 
-@app.get("/")
-async def root():
-    return {"message": "Hello from CodeWorld FastAPI"}
 
-@app.get("/health")
-async def health_check():
-    return {"status": "ok"} 
+if __name__ == "__main__":
+    uvicorn.run("app.main:app", host="0.0.0.0", port=80)

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter
+
+from .logic import get_health_status, get_root_message
+
+router = APIRouter()
+
+
+@router.get("/")
+async def root():
+    """Root endpoint for the API."""
+    return await get_root_message()
+
+
+@router.get("/health")
+async def health_check():
+    """Health check endpoint."""
+    return await get_health_status()


### PR DESCRIPTION
## Summary
- restructure the FastAPI application into dedicated modules for server setup, routes, and logic
- expose route handlers through an `APIRouter` and import logic helpers from a new module
- configure the application entry point to run with Uvicorn on port 80

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cd8f08280c8328a52a0da8da863b67