### PR TITLE
Add 3D bar complexity visualization with tabbed interface

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -418,6 +418,151 @@ main {
   border-bottom: none;
 }
 
+.results-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .results-card-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.results-card-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.chart-tab-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chart-tab-button {
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  color: #1e293b;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.chart-tab-button:hover,
+.chart-tab-button:focus-visible {
+  border-color: #3b82f6;
+  color: #1d4ed8;
+  background: #e0f2fe;
+}
+
+.chart-tab-button.active {
+  border-color: #1d4ed8;
+  background: #1d4ed8;
+  color: #ffffff;
+  box-shadow: 0 10px 20px rgba(29, 78, 216, 0.2);
+}
+
+.chart-tab-panel {
+  margin-top: 1rem;
+}
+
+.circle-packing-container,
+.three-d-bar-wrapper {
+  width: 100%;
+  max-width: 840px;
+  margin: 0 auto;
+  position: relative;
+}
+
+.circle-packing-container {
+  height: 600px;
+}
+
+.three-d-bar-wrapper {
+  height: 480px;
+}
+
+.chart-tooltip {
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  border-radius: 12px;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.18);
+  padding: 0.75rem 1rem;
+  color: #0f172a;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  min-width: 220px;
+  backdrop-filter: blur(4px);
+}
+
+.chart-tooltip h4 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+}
+
+.chart-tooltip p {
+  margin: 0.25rem 0;
+}
+
+.chart-tooltip .tooltip-list {
+  margin-top: 0.5rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.chart-tooltip .tooltip-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.axis-label,
+.axis-title,
+.bar-label,
+.bar-value,
+.legend-label {
+  font-family: 'Inter', sans-serif;
+  fill: #475569;
+}
+
+.axis-label {
+  font-size: 0.75rem;
+}
+
+.axis-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.bar-label {
+  font-size: 0.8rem;
+  fill: #1e293b;
+}
+
+.bar-value {
+  font-size: 0.75rem;
+  fill: #1e293b;
+  font-weight: 600;
+}
+
+.chart-legend {
+  font-size: 0.75rem;
+  fill: #475569;
+}
+
+.legend-label {
+  dominant-baseline: middle;
+}
+
 .function-name {
   color: #1e293b;
   font-weight: 500;

--- a/frontend/src/components/results/Complexity3DBarChart.jsx
+++ b/frontend/src/components/results/Complexity3DBarChart.jsx
@@ -1,0 +1,180 @@
+import React, { useMemo } from 'react'
+import * as d3 from 'd3'
+
+const Complexity3DBarChart = ({ files = [] }) => {
+  const processed = useMemo(() => {
+    return files
+      .filter((file) => file)
+      .map((file) => ({
+        id: file.filename,
+        label: file.filename?.split('/')?.pop() || file.filename || 'Unknown',
+        nloc: file.total_nloc ?? file.total_loc ?? 0,
+        functions: file.function_count ?? 0,
+        complexity: file.complexity_avg ?? 0,
+      }))
+      .filter((item) => item.nloc > 0 || item.functions > 0)
+  }, [files])
+
+  if (!processed.length) {
+    return <p className="empty-state">No file data available for visualization.</p>
+  }
+
+  const margin = { top: 40, right: 80, bottom: 120, left: 80 }
+  const chartHeight = 360
+  const frontWidth = 54
+  const gap = 46
+  const depthScale = 6
+
+  const maxNloc = Math.max(...processed.map((item) => item.nloc), 1)
+  const heights = processed.map((item) => (item.nloc / maxNloc) * chartHeight)
+  const depthValues = processed.map((item) => Math.max(16, (2 * (1 + item.functions)) * depthScale))
+  const maxDepth = Math.max(...depthValues, 32)
+
+  const svgWidth = margin.left + margin.right + processed.length * (frontWidth + gap) + maxDepth
+  const svgHeight = margin.top + margin.bottom + chartHeight + 20
+
+  const getColor = (complexity) => {
+    if (complexity < 5) return '#22c55e'
+    if (complexity < 10) return '#eab308'
+    return '#ef4444'
+  }
+
+  const adjustColor = (hex, amount) => {
+    const base = d3.color(hex)
+    if (!base) return hex
+    const hsl = base.hsl()
+    hsl.l = Math.max(0, Math.min(1, hsl.l + amount))
+    return hsl.formatHex()
+  }
+
+  const yTicks = 4
+  const tickValues = Array.from({ length: yTicks + 1 }, (_, index) => (maxNloc / yTicks) * index)
+
+  return (
+    <div className="three-d-bar-wrapper">
+      <svg
+        role="img"
+        aria-label="3D bar chart showing file complexity and size"
+        viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+        width="100%"
+        height="100%"
+      >
+        <defs>
+          <linearGradient id="chart-grid" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="#e2e8f0" stopOpacity="0.6" />
+            <stop offset="100%" stopColor="#e2e8f0" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+
+        <g>
+          {tickValues.map((tick, index) => {
+            const y = margin.top + chartHeight - (tick / maxNloc) * chartHeight
+            return (
+              <g key={`tick-${index}`}>
+                <line
+                  x1={margin.left - 8}
+                  x2={svgWidth - margin.right + maxDepth}
+                  y1={y}
+                  y2={y}
+                  stroke="url(#chart-grid)"
+                  strokeWidth={1}
+                />
+                <text x={margin.left - 16} y={y + 4} textAnchor="end" className="axis-label">
+                  {Math.round(tick)}
+                </text>
+              </g>
+            )
+          })}
+        </g>
+
+        <text
+          x={margin.left - 50}
+          y={margin.top - 16}
+          className="axis-title"
+          transform={`rotate(-90 ${margin.left - 50} ${margin.top - 16})`}
+        >
+          Logical LOC
+        </text>
+
+        <g>
+          {processed.map((item, index) => {
+            const height = heights[index]
+            const depth = depthValues[index]
+            const x = margin.left + index * (frontWidth + gap)
+            const y = margin.top + (chartHeight - height)
+            const depthYOffset = depth * 0.45
+            const frontColor = getColor(item.complexity)
+            const topColor = adjustColor(frontColor, 0.18)
+            const sideColor = adjustColor(frontColor, -0.1)
+            const complexityLabel =
+              typeof item.complexity === 'number'
+                ? item.complexity.toFixed(2)
+                : item.complexity
+
+            return (
+              <g key={item.id || index} className="three-d-bar">
+                <polygon
+                  points={`
+                    ${x},${y}
+                    ${x + depth},${y - depthYOffset}
+                    ${x + depth + frontWidth},${y - depthYOffset}
+                    ${x + frontWidth},${y}
+                  `}
+                  fill={topColor}
+                />
+                <polygon
+                  points={`
+                    ${x + frontWidth},${y}
+                    ${x + frontWidth + depth},${y - depthYOffset}
+                    ${x + frontWidth + depth},${y + height - depthYOffset}
+                    ${x + frontWidth},${y + height}
+                  `}
+                  fill={sideColor}
+                />
+                <rect
+                  x={x}
+                  y={y}
+                  width={frontWidth}
+                  height={height}
+                  fill={frontColor}
+                  rx={6}
+                />
+                <text
+                  x={x + frontWidth / 2}
+                  y={margin.top + chartHeight + 24}
+                  textAnchor="middle"
+                  className="bar-label"
+                >
+                  {item.label}
+                </text>
+                <text x={x + frontWidth / 2} y={y - depthYOffset - 8} textAnchor="middle" className="bar-value">
+                  {item.nloc} nloc
+                </text>
+                <title>
+                  {`${item.label}\nLogical LOC: ${item.nloc}\nFunctions: ${item.functions}\nAvg CC: ${complexityLabel}`}
+                </title>
+              </g>
+            )
+          })}
+        </g>
+
+        <g className="chart-legend" transform={`translate(${svgWidth - margin.right - 160}, ${margin.top})`}>
+          <rect width="12" height="12" fill="#22c55e" rx="2" />
+          <text x="18" y="11" className="legend-label">
+            CC &lt; 5
+          </text>
+          <rect x="0" y="22" width="12" height="12" fill="#eab308" rx="2" />
+          <text x="18" y="33" className="legend-label">
+            5 ≤ CC &lt; 10
+          </text>
+          <rect x="0" y="44" width="12" height="12" fill="#ef4444" rx="2" />
+          <text x="18" y="55" className="legend-label">
+            CC ≥ 10
+          </text>
+        </g>
+      </svg>
+    </div>
+  )
+}
+
+export default Complexity3DBarChart

--- a/frontend/src/components/results/FolderCirclePackingChart.jsx
+++ b/frontend/src/components/results/FolderCirclePackingChart.jsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useRef } from 'react'
+import * as d3 from 'd3'
+
+const FolderCirclePackingChart = ({ folderName, files }) => {
+  const chartRef = useRef(null)
+
+  useEffect(() => {
+    if (!files?.length) return
+
+    const width = 800
+    const height = 600
+    const margin = 20
+
+    const container = d3.select(chartRef.current)
+    container.selectAll('*').remove()
+
+    const svg = container
+      .append('svg')
+      .attr('viewBox', `0 0 ${width} ${height}`)
+      .attr('width', '100%')
+      .attr('height', '100%')
+
+    const tooltip = container
+      .append('div')
+      .attr('class', 'chart-tooltip')
+      .style('position', 'absolute')
+      .style('opacity', 0)
+      .style('pointer-events', 'none')
+
+    const complexities = files.map((file) => file.complexity_avg).filter((value) => typeof value === 'number')
+    const minComplexity = complexities.length > 0 ? Math.min(...complexities) : 0
+    const maxComplexity = complexities.length > 0 ? Math.max(...complexities) : 10
+
+    const colorScale = d3
+      .scaleLinear()
+      .domain([minComplexity, (minComplexity + maxComplexity) / 2, maxComplexity || 10])
+      .range(['#22c55e', '#facc15', '#ef4444'])
+
+    const data = {
+      name: folderName,
+      children: files.map((file) => ({
+        name: file.filename.split('/').pop(),
+        total_nloc: file.total_nloc || 0,
+        complexity_avg: file.complexity_avg || 0,
+        complexity_max: file.complexity_max || 0,
+        function_count: file.function_count || 0,
+        functions: file.functions || [],
+      })),
+    }
+
+    const hierarchy = d3
+      .hierarchy(data)
+      .sum((d) => d.total_nloc)
+      .sort((a, b) => b.value - a.value)
+
+    const pack = d3.pack().size([width - margin * 2, height - margin * 2]).padding(10)
+
+    const root = pack(hierarchy)
+
+    const chartGroup = svg.append('g').attr('transform', `translate(${margin}, ${margin})`)
+
+    const nodes = chartGroup
+      .selectAll('g')
+      .data(root.descendants())
+      .enter()
+      .append('g')
+      .attr('transform', (d) => `translate(${d.x}, ${d.y})`)
+
+    nodes
+      .append('circle')
+      .attr('r', (d) => d.r)
+      .attr('fill', (d) => (d.children ? 'none' : colorScale(d.data.complexity_avg)))
+      .attr('stroke', (d) => (d.children ? '#1f2937' : 'none'))
+      .attr('stroke-width', (d) => (d.children ? 2 : 0))
+      .on('mouseover', function (event, d) {
+        const [x, y] = d3.pointer(event, container.node())
+        tooltip
+          .style('opacity', 0.95)
+          .style('left', `${x + 12}px`)
+          .style('top', `${y - 28}px`)
+          .html(generateTooltip(d.data))
+      })
+      .on('mousemove', function (event) {
+        const [x, y] = d3.pointer(event, container.node())
+        tooltip.style('left', `${x + 12}px`).style('top', `${y - 28}px`)
+      })
+      .on('mouseout', function () {
+        tooltip.style('opacity', 0)
+      })
+
+    svg
+      .append('circle')
+      .attr('cx', root.x + margin)
+      .attr('cy', root.y + margin)
+      .attr('r', root.r)
+      .attr('fill', 'none')
+      .attr('stroke', '#111827')
+      .attr('stroke-width', 2)
+
+    function generateTooltip(d) {
+      if (!d.name) {
+        return `<strong>${folderName}</strong>`
+      }
+
+      let html = `
+        <div class="tooltip-content">
+          <h4>${d.name}</h4>
+          <p><strong>Logical LOC:</strong> ${d.total_nloc}</p>
+          <p><strong>Functions:</strong> ${d.function_count}</p>
+          <p><strong>Avg CC:</strong> ${d.complexity_avg}</p>
+          <p><strong>Max CC:</strong> ${d.complexity_max}</p>
+        </div>
+      `
+
+      if (d.functions?.length) {
+        html += '<div class="tooltip-list"><strong>Functions</strong>'
+        d.functions.slice(0, 5).forEach((fn) => {
+          html += `
+            <div class="tooltip-row">
+              <span>${fn.name}</span>
+              <span>nloc: ${fn.nloc}</span>
+              <span>CC: ${fn.cyclomatic_complexity}</span>
+            </div>
+          `
+        })
+        if (d.functions.length > 5) {
+          html += `<div class="tooltip-row">…and ${d.functions.length - 5} more</div>`
+        }
+        html += '</div>'
+      }
+
+      return html
+    }
+
+    return () => {
+      container.selectAll('*').remove()
+    }
+  }, [files, folderName])
+
+  return <div ref={chartRef} className="circle-packing-container"></div>
+}
+
+export default FolderCirclePackingChart

--- a/frontend/src/components/results/FolderResults.jsx
+++ b/frontend/src/components/results/FolderResults.jsx
@@ -1,6 +1,7 @@
-import React, { useRef, useEffect } from 'react'
-import * as d3 from 'd3'
+import React, { useMemo, useState } from 'react'
 import InfoTip from '../common/InfoTip'
+import FolderCirclePackingChart from './FolderCirclePackingChart'
+import Complexity3DBarChart from './Complexity3DBarChart'
 
 const FOLDER_METRIC_HELP = {
   'Total files': 'Number of JavaScript files analyzed within the folder.',
@@ -17,129 +18,22 @@ function FolderResults({ analysisResult, onBack }) {
   const { folder_name, analysis } = analysisResult
   const { folder_metrics, individual_files } = analysis
 
-  const chartRef = useRef(null)
-  const tooltipRef = useRef(null)
+  const [activeTab, setActiveTab] = useState('circle')
 
-  useEffect(() => {
-    if (!individual_files?.length) return
+  const chartTabs = useMemo(
+    () => [
+      { id: 'circle', label: 'Circle packing' },
+      { id: 'bars', label: '3D complexity bars' },
+    ],
+    []
+  )
 
-    const width = 800
-    const height = 600
-    const margin = 20
+  const hasFiles = Boolean(individual_files?.length)
 
-    const container = d3.select(chartRef.current)
-    container.html('')
-
-    const svg = container.append('svg')
-      .attr('width', width)
-      .attr('height', height)
-
-    const tooltip = d3.select('body').append('div')
-      .attr('class', 'd3-tooltip')
-      .style('position', 'absolute')
-      .style('opacity', 0)
-      .style('background', 'white')
-      .style('border', '1px solid black')
-      .style('padding', '10px')
-      .style('border-radius', '5px')
-      .style('pointer-events', 'none')
-      .style('max-width', '300px')
-      .style('box-shadow', '0 2px 10px rgba(0,0,0,0.1)')
-
-    const complexities = individual_files
-      .map(f => f.complexity_avg)
-      .filter(Boolean)
-    const minComplexity = complexities.length > 0 ? Math.min(...complexities) : 1
-    const maxComplexity = complexities.length > 0 ? Math.max(...complexities) : 10
-
-    const colorScale = d3.scaleLinear()
-      .domain([minComplexity, maxComplexity])
-      .range(['green', 'red'])
-
-    const data = {
-      name: folder_name,
-      children: individual_files.map(file => ({
-        name: file.filename.split('/').pop(),
-        total_nloc: file.total_nloc || 0,
-        complexity_avg: file.complexity_avg || 0,
-        complexity_max: file.complexity_max || 0,
-        function_count: file.function_count || 0,
-        functions: file.functions || []
-      }))
-    }
-
-    const hierarchy = d3.hierarchy(data)
-      .sum(d => d.total_nloc)
-
-    const pack = d3.pack()
-      .size([width - margin * 2, height - margin * 2])
-      .padding(10)
-
-    const rootNode = pack(hierarchy)
-
-    // Draw file circles
-    svg.selectAll('circle')
-      .data(rootNode.children)
-      .enter()
-      .append('circle')
-      .attr('cx', d => d.x + margin)
-      .attr('cy', d => d.y + margin)
-      .attr('r', d => d.r)
-      .attr('fill', d => colorScale(d.data.complexity_avg))
-      .attr('stroke', 'white')
-      .attr('stroke-width', 1)
-      .on('mouseover', function(event, d) {
-        tooltip.transition()
-          .duration(200)
-          .style('opacity', 0.9)
-        tooltip.html(generateTooltipHtml(d.data))
-          .style('left', (event.pageX + 10) + 'px')
-          .style('top', (event.pageY - 28) + 'px')
-      })
-      .on('mouseout', function() {
-        tooltip.transition()
-          .duration(500)
-          .style('opacity', 0)
-      })
-
-    // Draw folder hollow circle
-    svg.append('circle')
-      .attr('cx', rootNode.x + margin)
-      .attr('cy', rootNode.y + margin)
-      .attr('r', rootNode.r)
-      .attr('fill', 'none')
-      .attr('stroke', 'black')
-      .attr('stroke-width', 2)
-
-    function generateTooltipHtml(d) {
-      let html = `
-        <h4 style="margin: 0 0 10px 0;">${d.name}</h4>
-        <p><strong>Logical LOC:</strong> ${d.total_nloc}</p>
-        <p><strong>Functions:</strong> ${d.function_count}</p>
-        <p><strong>Avg. Complexity:</strong> ${d.complexity_avg}</p>
-        <p><strong>Max. Complexity:</strong> ${d.complexity_max}</p>
-      `
-      if (d.functions.length > 0) {
-        html += `<details style="margin-top: 10px;"><summary>Functions (${d.functions.length})</summary>`
-        d.functions.forEach(fn => {
-          html += `
-            <div style="margin: 5px 0; padding: 2px; border-left: 2px solid #ccc;">
-              <span style="font-weight: bold;">${fn.name}</span>
-              <span style="margin-left: 10px;">nloc: ${fn.nloc}</span>
-              <span style="margin-left: 10px;">CC: ${fn.cyclomatic_complexity}</span>
-            </div>
-          `
-        })
-        html += '</details>'
-      }
-      return html
-    }
-
-    return () => {
-      svg.remove()
-      tooltip.remove()
-    }
-  }, [analysisResult])
+  const tabDescription =
+    activeTab === 'circle'
+      ? 'Circle packing visualization: The outer ring represents the folder. Inner circles show files sized by logical LOC and colored by average complexity.'
+      : '3D bar visualization: Bar height represents logical LOC, width encodes function count, and color reflects average cyclomatic complexity.'
 
   const folderSummaryItems = [
     { label: 'Total files', value: folder_metrics?.total_files },
@@ -181,11 +75,35 @@ function FolderResults({ analysisResult, onBack }) {
           </div>
         </section>
 
-        {individual_files?.length > 0 && (
+        {hasFiles && (
           <section className="results-card">
-            <h2>Complexity Visualization</h2>
-            <InfoTip text="Circle packing visualization: The large hollow circle represents the folder. Inner circles represent files, sized by logical LOC (nloc) and colored by average complexity (green: low, red: high). Hover for details." ariaLabel="Help: Complexity Visualization" />
-            <div ref={chartRef} className="chart-container" style={{ width: '800px', height: '600px', margin: '0 auto' }}></div>
+            <div className="results-card-header">
+              <div className="results-card-title">
+                <h2>Complexity Visualization</h2>
+                <InfoTip text={tabDescription} ariaLabel="Help: Complexity Visualization" />
+              </div>
+              <div className="chart-tab-buttons" role="tablist" aria-label="Complexity visualizations">
+                {chartTabs.map((tab) => (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    role="tab"
+                    aria-selected={activeTab === tab.id}
+                    className={`chart-tab-button ${activeTab === tab.id ? 'active' : ''}`}
+                    onClick={() => setActiveTab(tab.id)}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="chart-tab-panel" role="tabpanel">
+              {activeTab === 'circle' ? (
+                <FolderCirclePackingChart folderName={folder_name} files={individual_files} />
+              ) : (
+                <Complexity3DBarChart files={individual_files} />
+              )}
+            </div>
           </section>
         )}
 


### PR DESCRIPTION
## Summary
- add a 3D bar chart component for folder analysis results with height, width, and color mapped to metrics
- extract the circle packing visualization into a dedicated component and present both charts in a tabbed interface
- update styling to support the new tab controls, tooltips, and chart typography

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e36b13f9a88328876ce21736c35158