### PR TITLE
Add bar chart option to folder complexity visualization

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -290,6 +290,13 @@ main {
   gap: 1.5rem;
 }
 
+.results-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .results-card h2 {
   margin: 0;
   font-size: 1.35rem;
@@ -352,6 +359,50 @@ main {
 .empty-state {
   margin: 0;
   color: #64748b;
+}
+
+.visualization-tabs {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.visualization-tab-button {
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  color: #475569;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.visualization-tab-button:hover,
+.visualization-tab-button:focus-visible {
+  border-color: #3b82f6;
+  color: #1d4ed8;
+}
+
+.visualization-tab-button.active {
+  background: #3b82f6;
+  border-color: #3b82f6;
+  color: #ffffff;
+}
+
+.visualization-tab-panel {
+  display: block;
+}
+
+.complexity-bar-chart {
+  display: block;
+  max-width: 100%;
+}
+
+.complexity-bar-chart .bar-label {
+  fill: #1f2937;
+  font-size: 0.8rem;
+  font-weight: 500;
 }
 
 .files-grid {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -479,12 +479,6 @@ main {
   font-size: 0.8rem;
 }
 
-
-.function-sub {
-  color: #64748b;
-  font-size: 0.8rem;
-}
-
 .progress-bar {
   height: 10px;
   background: #e2e8f0;

--- a/frontend/src/components/results/CirclePacking.jsx
+++ b/frontend/src/components/results/CirclePacking.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from 'react'
 import * as d3 from 'd3'
-import InfoTip from '../common/InfoTip'
 
 function CirclePacking({ data }) {
   const ref = useRef()
@@ -13,7 +12,7 @@ function CirclePacking({ data }) {
 
     const colorScale = d3.scaleLinear()
       .domain([0, 10, 20]) // adjust based on typical CC ranges
-      .range(["green", "yellow", "red"])
+      .range(['green', 'yellow', 'red'])
 
     // Build a hierarchy from files/functions
     const root = d3.hierarchy(data)
@@ -27,27 +26,27 @@ function CirclePacking({ data }) {
     pack(root)
 
     const svg = d3.select(ref.current)
-      .attr("viewBox", [0, 0, width, height])
-      .attr("text-anchor", "middle")
-      .style("font-family", "sans-serif")
-      .style("font-size", 10)
+      .attr('viewBox', [0, 0, width, height])
+      .attr('text-anchor', 'middle')
+      .style('font-family', 'sans-serif')
+      .style('font-size', 10)
 
-    svg.selectAll("*").remove() // clear previous render
+    svg.selectAll('*').remove() // clear previous render
 
-    const node = svg.append("g")
-      .selectAll("circle")
+    const node = svg.append('g')
+      .selectAll('circle')
       .data(root.descendants())
-      .join("g")
-      .attr("transform", d => `translate(${d.x},${d.y})`)
+      .join('g')
+      .attr('transform', d => `translate(${d.x},${d.y})`)
 
     // Draw circles
-    node.append("circle")
-      .attr("r", d => d.r)
-      .attr("fill", d => d.children ? "none" : colorScale(d.data.complexity || 0))
-      .attr("stroke", d => d.children ? "#555" : "none")
+    node.append('circle')
+      .attr('r', d => d.r)
+      .attr('fill', d => (d.children ? 'none' : colorScale(d.data.complexity || 0)))
+      .attr('stroke', d => (d.children ? '#555' : 'none'))
 
     // Tooltip
-    node.append("title")
+    node.append('title')
       .text(d => {
         if (d.data.filename) {
           return `${d.data.filename}\nLOC: ${d.data.nloc}\nAvg CC: ${d.data.complexity}`
@@ -55,7 +54,7 @@ function CirclePacking({ data }) {
         if (d.data.name) {
           return `${d.data.name}\nLOC: ${d.data.nloc}\nCC: ${d.data.cyclomatic_complexity}`
         }
-        return "Folder"
+        return 'Folder'
       })
   }, [data])
 

--- a/frontend/src/components/results/ComplexityBarChart.jsx
+++ b/frontend/src/components/results/ComplexityBarChart.jsx
@@ -72,8 +72,10 @@ function ComplexityBarChart({ files = [] }) {
           </rect>
           <text
             x={bar.width / 2}
-            y={bar.height + 16}
-            textAnchor="middle"
+            y={bar.height + 18}
+            textAnchor="start"
+            dominantBaseline="hanging"
+            transform={`rotate(45 ${bar.width / 2} ${bar.height + 18})`}
             className="bar-label"
           >
             {bar.label.split('/').pop()}

--- a/frontend/src/components/results/ComplexityBarChart.jsx
+++ b/frontend/src/components/results/ComplexityBarChart.jsx
@@ -1,0 +1,94 @@
+import React, { useMemo } from 'react'
+
+const CHART_HEIGHT = 400
+const LABEL_AREA = 80
+const WIDTH_UNIT = 20
+const BAR_GAP = 24
+
+function getBarColor(complexity = 0) {
+  if (complexity < 5) return '#2ecc71'
+  if (complexity <= 10) return '#f1c40f'
+  return '#e74c3c'
+}
+
+function ComplexityBarChart({ files = [] }) {
+  const prepared = useMemo(() => {
+    const maxNloc = Math.max(...files.map(file => file.total_nloc || file.total_loc || 0), 1)
+
+    let currentX = BAR_GAP
+
+    const bars = files.map(file => {
+      const nloc = file.total_nloc || file.total_loc || 0
+      const functionCount = file.function_count || 0
+      const complexity = file.complexity_avg ?? file.complexity_max ?? 0
+
+      const scaledHeight = (nloc / maxNloc) * CHART_HEIGHT
+      const rawWidth = 2 * (1 + functionCount)
+      const scaledWidth = Math.max(rawWidth * WIDTH_UNIT, WIDTH_UNIT) // ensure visible even when 0 functions
+
+      const bar = {
+        x: currentX,
+        width: scaledWidth,
+        height: scaledHeight,
+        label: file.filename,
+        nloc,
+        functionCount,
+        complexity
+      }
+
+      currentX += scaledWidth + BAR_GAP
+      return bar
+    })
+
+    const svgWidth = Math.max(currentX, 600)
+
+    return { bars, svgWidth, maxNloc }
+  }, [files])
+
+  if (!files.length) {
+    return <p className="empty-state">No data available for the bar chart.</p>
+  }
+
+  return (
+    <svg
+      role="img"
+      aria-label="Bar chart comparing file complexity and size"
+      width={prepared.svgWidth}
+      height={CHART_HEIGHT + LABEL_AREA}
+      className="complexity-bar-chart"
+    >
+      {prepared.bars.map((bar, index) => (
+        <g key={bar.label || index} transform={`translate(${bar.x}, ${CHART_HEIGHT - bar.height})`}>
+          <rect
+            width={bar.width}
+            height={bar.height}
+            fill={getBarColor(bar.complexity)}
+            rx={6}
+            ry={6}
+          >
+            <title>
+              {`${bar.label}\nLogical LOC: ${bar.nloc}\nFunctions: ${bar.functionCount}\nAvg CC: ${bar.complexity}`}
+            </title>
+          </rect>
+          <text
+            x={bar.width / 2}
+            y={bar.height + 16}
+            textAnchor="middle"
+            className="bar-label"
+          >
+            {bar.label.split('/').pop()}
+          </text>
+        </g>
+      ))}
+      <line
+        x1={0}
+        x2={prepared.svgWidth}
+        y1={CHART_HEIGHT}
+        y2={CHART_HEIGHT}
+        stroke="#ccc"
+      />
+    </svg>
+  )
+}
+
+export default ComplexityBarChart

--- a/frontend/src/components/results/FolderResults.jsx
+++ b/frontend/src/components/results/FolderResults.jsx
@@ -1,6 +1,7 @@
-import React, { useRef, useEffect } from 'react'
+import React, { useRef, useEffect, useState } from 'react'
 import * as d3 from 'd3'
 import InfoTip from '../common/InfoTip'
+import ComplexityBarChart from './ComplexityBarChart'
 
 const FOLDER_METRIC_HELP = {
   'Total files': 'Number of JavaScript files analyzed within the folder.',
@@ -18,17 +19,28 @@ function FolderResults({ analysisResult, onBack }) {
   const { folder_metrics, individual_files } = analysis
 
   const chartRef = useRef(null)
-  const tooltipRef = useRef(null)
+  const [activeTab, setActiveTab] = useState('circle')
+  const circleTabId = 'visualization-tab-circle'
+  const barTabId = 'visualization-tab-bar'
+  const panelId = 'visualization-tab-panel'
 
   useEffect(() => {
-    if (!individual_files?.length) return
+    if (!chartRef.current) {
+      d3.selectAll('.d3-tooltip').remove()
+      return
+    }
+
+    const container = d3.select(chartRef.current)
+    container.html('')
+
+    if (!individual_files?.length || activeTab !== 'circle') {
+      d3.selectAll('.d3-tooltip').remove()
+      return
+    }
 
     const width = 800
     const height = 600
     const margin = 20
-
-    const container = d3.select(chartRef.current)
-    container.html('')
 
     const svg = container.append('svg')
       .attr('width', width)
@@ -77,7 +89,6 @@ function FolderResults({ analysisResult, onBack }) {
 
     const rootNode = pack(hierarchy)
 
-    // Draw file circles
     svg.selectAll('circle')
       .data(rootNode.children)
       .enter()
@@ -102,7 +113,6 @@ function FolderResults({ analysisResult, onBack }) {
           .style('opacity', 0)
       })
 
-    // Draw folder hollow circle
     svg.append('circle')
       .attr('cx', rootNode.x + margin)
       .attr('cy', rootNode.y + margin)
@@ -139,7 +149,7 @@ function FolderResults({ analysisResult, onBack }) {
       svg.remove()
       tooltip.remove()
     }
-  }, [analysisResult])
+  }, [activeTab, individual_files, folder_name])
 
   const folderSummaryItems = [
     { label: 'Total files', value: folder_metrics?.total_files },
@@ -183,9 +193,55 @@ function FolderResults({ analysisResult, onBack }) {
 
         {individual_files?.length > 0 && (
           <section className="results-card">
-            <h2>Complexity Visualization</h2>
-            <InfoTip text="Circle packing visualization: The large hollow circle represents the folder. Inner circles represent files, sized by logical LOC (nloc) and colored by average complexity (green: low, red: high). Hover for details." ariaLabel="Help: Complexity Visualization" />
-            <div ref={chartRef} className="chart-container" style={{ width: '800px', height: '600px', margin: '0 auto' }}></div>
+            <div className="results-card-header">
+              <h2>Complexity Visualization</h2>
+              <InfoTip
+                text="Compare folder complexity with circle packing or bar chart views. Circle packing uses circle size for LOC and color for complexity; the bar chart uses height for LOC, width for function count, and color for average complexity."
+                ariaLabel="Help: Complexity Visualization"
+              />
+            </div>
+
+            <div className="visualization-tabs" role="tablist" aria-label="Complexity visualizations">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === 'circle'}
+                id={circleTabId}
+                aria-controls={panelId}
+                tabIndex={activeTab === 'circle' ? 0 : -1}
+                className={`visualization-tab-button ${activeTab === 'circle' ? 'active' : ''}`}
+                onClick={() => setActiveTab('circle')}
+              >
+                Circle Packing
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={activeTab === 'bar'}
+                id={barTabId}
+                aria-controls={panelId}
+                tabIndex={activeTab === 'bar' ? 0 : -1}
+                className={`visualization-tab-button ${activeTab === 'bar' ? 'active' : ''}`}
+                onClick={() => setActiveTab('bar')}
+              >
+                Complexity Bars
+              </button>
+            </div>
+
+            <div
+              className="visualization-tab-panel"
+              role="tabpanel"
+              id={panelId}
+              aria-labelledby={activeTab === 'circle' ? circleTabId : barTabId}
+            >
+              {activeTab === 'circle' ? (
+                <div ref={chartRef} className="chart-container" style={{ width: '800px', height: '600px', margin: '0 auto' }}></div>
+              ) : (
+                <div className="chart-container" style={{ overflowX: 'auto' }}>
+                  <ComplexityBarChart files={individual_files} />
+                </div>
+              )}
+            </div>
           </section>
         )}
 
@@ -206,7 +262,7 @@ function FolderResults({ analysisResult, onBack }) {
                       <span>Max Complexity: {file.complexity_max}</span>
                     </div>
                   </div>
-                  
+
                   {file.functions?.length > 0 && (
                     <details className="function-details">
                       <summary>Functions ({file.functions.length})</summary>


### PR DESCRIPTION
## Summary
- add a reusable `ComplexityBarChart` component that visualizes folder metrics with nloc-based bar heights, function-based widths, and complexity-based coloring
- update folder results to show the complexity section as a tabbed interface that can switch between the existing circle packing view and the new bar chart
- style the new tab controls and bar chart labels to match the existing results UI

## Testing
- npm install --no-progress *(fails: ENOTEMPTY rename error in npm)*

------
https://chatgpt.com/codex/tasks/task_e_68e370972a708328b4f3120848104e83