### PR TITLE
Add halstead_volume across analyzers

### DIFF
--- a/backend/app/js_plugin/server.js
+++ b/backend/app/js_plugin/server.js
@@ -137,6 +137,7 @@ function calculateMetrics(code) {
             CC: globalCC,
             CYC: globalCYC,
             MI: parseFloat(globalMI.toFixed(2)),
+            halsteadVolume: 0.0,
             maxNesting: globalMaxNesting,
             lineStart: 1,
             lineEnd: loc,
@@ -256,6 +257,7 @@ function calculateMetrics(code) {
                     CC: complexity,
                     CYC: cyclomaticComplexity,
                     MI: parseFloat(mi.toFixed(2)),
+                    halsteadVolume: fnHalsteadVolume,
                     maxNesting,
                     lineStart,
                     lineEnd,
@@ -686,7 +688,7 @@ app.post('/analyze-code', express.json(), (req, res) => {
                 cyclomatic_complexity: f.CYC,
                 maintainability_index: f.MI ?? 100.0,
                 nloc: f.NLOC,
-                token_count: 0,
+                halstead_volume: f.halsteadVolume || 0.0,
                 name: f.name,
                 long_name: currentLongName,
                 start_line: f.lineStart,
@@ -729,6 +731,7 @@ app.post('/analyze-code', express.json(), (req, res) => {
             function_count: function_count,
             total_complexity: babelMetrics.fileCYC !== undefined ? babelMetrics.fileCYC : complexity_sum,
             complexity_max: complexity_max,
+            halstead_volume: babelMetrics.halsteadVolume || 0.0,
             maintainability_index: parseFloat(maintainability_index.toFixed(2)),
             functions: hierarchicalFunctions, // Returns roots with nested children
         };
@@ -790,7 +793,7 @@ app.post('/analyze-batch', express.json({ limit: '50mb' }), (req, res) => {
                     cognitive_complexity: f.CC,
                     total_cognitive_complexity: f.totalCC,
                     nloc: f.NLOC,
-                    token_count: 0,
+                    halstead_volume: f.halsteadVolume || 0.0,
                     name: f.name,
                     long_name: currentLongName,
                     start_line: f.lineStart,
@@ -816,6 +819,7 @@ app.post('/analyze-batch', express.json({ limit: '50mb' }), (req, res) => {
                 function_count: babelMetrics.functions.length,
                 total_complexity: complexity_sum,
                 complexity_max,
+                halstead_volume: babelMetrics.halsteadVolume || 0.0,
                 functions: hierarchicalFunctions,
             };
         } catch (error) {

--- a/backend/app/model/analyzer_model.py
+++ b/backend/app/model/analyzer_model.py
@@ -13,7 +13,7 @@ class FunctionMetric(BaseModel):
     total_cognitive_complexity: Optional[int] = None
     maintainability_index: Optional[float] = None
     max_nesting_depth: int
-    token_count: int
+    halstead_volume: Optional[float] = None
     id: Optional[int] = None
     parentId: Optional[int] = None
     children: List['FunctionMetric'] = Field(default_factory=list)
@@ -26,6 +26,7 @@ class FileMetrics(BaseModel):
     function_count: int
     total_complexity: int
     complexity_max: int
+    halstead_volume: Optional[float] = None
     maintainability_index: Optional[float] = None
     is_unsupported: bool = False
     functions: List[FunctionMetric]

--- a/backend/app/python_plugin/python_analyzer.py
+++ b/backend/app/python_plugin/python_analyzer.py
@@ -245,7 +245,7 @@ def calculate_metrics(code: str, filename: str) -> FileMetrics:
         cognitive_complexity=global_res["complexity"],
         cyclomatic_complexity=int(lizard_global_cc) if lizard_global_cc else 1,
         nloc=0, # To be updated
-        token_count=0,
+        halstead_volume=0.0,
         maintainability_index=100.0,
         start_line=1,
         end_line=len(code.splitlines()),
@@ -337,7 +337,7 @@ def calculate_metrics(code: str, filename: str) -> FileMetrics:
                 cognitive_complexity=res["complexity"],
                 cyclomatic_complexity=0, # Will be set via lizard
                 nloc=func_nloc,
-                token_count=0,
+                halstead_volume=fn_halstead_map.get(start_line, 0.0),
                 start_line=start_line,
                 end_line=end_line,
                 max_nesting_depth=res["max_nesting"],
@@ -451,6 +451,7 @@ def calculate_metrics(code: str, filename: str) -> FileMetrics:
         function_count=len(functions),
         total_complexity=complexity_sum,
         complexity_max=complexity_max,
+        halstead_volume=halstead_volume,
         maintainability_index=maintainability_index,
         functions=roots
     )

--- a/backend/app/services/analyze_local_folder.py
+++ b/backend/app/services/analyze_local_folder.py
@@ -135,6 +135,7 @@ def _incremental_analysis(
 
     # 3. Aggregate metrics
     total_loc = total_nloc = total_functions = total_complexity = complexity_max = 0
+    halstead_volume = 0.0
     for fm in file_metrics_list:
         total_loc += fm.total_loc
         total_nloc += fm.total_nloc
@@ -142,13 +143,15 @@ def _incremental_analysis(
         total_complexity += fm.total_complexity
         if (fm.complexity_max or 0) > complexity_max:
             complexity_max = fm.complexity_max
+        if fm.halstead_volume is not None:
+            halstead_volume += fm.halstead_volume
 
     folder_metrics = FolderMetrics(
         folder_name=os.path.basename(local_path),
         total_files=len(file_metrics_list),
         total_loc=total_loc, total_nloc=total_nloc,
         total_functions=total_functions, total_complexity=total_complexity,
-        complexity_max=complexity_max, files=file_metrics_list,
+        complexity_max=complexity_max, halstead_volume=halstead_volume, files=file_metrics_list,
     )
     return FolderAnalysisResult(folder_metrics=folder_metrics, individual_files=file_metrics_list)
 
@@ -247,6 +250,7 @@ def analyze_local_folder(
         progress_callback(95, "Aggregating metrics")
 
     total_loc = total_nloc = total_functions = total_complexity = complexity_max = 0
+    halstead_volume = 0.0
     total_mi = 0.0
     valid_mi_files = 0
     for fm in file_metrics_list:
@@ -256,6 +260,8 @@ def analyze_local_folder(
         total_complexity += fm.total_complexity
         if (fm.complexity_max or 0) > complexity_max:
             complexity_max = fm.complexity_max
+        if fm.halstead_volume is not None:
+            halstead_volume += fm.halstead_volume
         if getattr(fm, 'maintainability_index', None) is not None:
             total_mi += fm.maintainability_index
             valid_mi_files += 1
@@ -268,6 +274,7 @@ def analyze_local_folder(
         total_functions=total_functions,
         total_complexity=total_complexity,
         complexity_max=complexity_max,
+        halstead_volume=halstead_volume,
         maintainability_index=round(total_mi / valid_mi_files, 2) if valid_mi_files > 0 else None,
         files=file_metrics_list,
     )

--- a/backend/app/utils/get_folder_matrix.py
+++ b/backend/app/utils/get_folder_matrix.py
@@ -61,6 +61,7 @@ async def get_folder_matrix(zip_content: bytes, folder_name: str) -> FolderAnaly
         total_functions = 0
         total_complexity = 0
         complexity_max = 0
+        halstead_volume = 0.0
         
         # Get list of adapters
         adapters = get_adapters()
@@ -81,6 +82,9 @@ async def get_folder_matrix(zip_content: bytes, folder_name: str) -> FolderAnaly
                 
                 if file_metrics.complexity_max > complexity_max:
                     complexity_max = file_metrics.complexity_max
+                
+                if file_metrics.halstead_volume is not None:
+                    halstead_volume += file_metrics.halstead_volume
         
         folder_metrics = FolderMetrics(
             folder_name=folder_name,
@@ -90,6 +94,7 @@ async def get_folder_matrix(zip_content: bytes, folder_name: str) -> FolderAnaly
             total_functions=total_functions,
             total_complexity=total_complexity,
             complexity_max=complexity_max,
+            halstead_volume=halstead_volume,
             files=file_metrics_list
         )
         

--- a/backend/app/utils/normalize.py
+++ b/backend/app/utils/normalize.py
@@ -59,6 +59,7 @@ def normalize_node_metrics(
         function_count=function_count,
         total_complexity=cc_sum,
         complexity_max=cc_max,
+        halstead_volume=0.0,
         functions=funcs,
     )
 
@@ -75,6 +76,7 @@ def normalize_node_zip(node_result: Dict[str, Any], folder_name: str = "src") ->
     total_loc = total_nloc = total_functions = 0
     cc_sum = 0
     cc_max_global = 0
+    halstead_volume_global = 0.0
 
     for file_result in results:
         filename = file_result.get("fileName")
@@ -90,6 +92,8 @@ def normalize_node_zip(node_result: Dict[str, Any], folder_name: str = "src") ->
             total_functions += fm.function_count
             cc_sum += fm.total_complexity
             cc_max_global = max(cc_max_global, fm.complexity_max)
+            if fm.halstead_volume is not None:
+                halstead_volume_global += fm.halstead_volume
         except Exception:
             # Handle potential errors during normalization
             continue
@@ -104,6 +108,7 @@ def normalize_node_zip(node_result: Dict[str, Any], folder_name: str = "src") ->
         total_functions=total_functions,
         total_complexity=cc_sum,
         complexity_max=cc_max_global,
+        halstead_volume=halstead_volume_global,
         files=all_files,
     )
 


### PR DESCRIPTION
Introduce halstead_volume metric throughout the analysis pipeline and models. Updated JS analyzer to emit halsteadVolume per-function and file-level halstead_volume in API responses; replaced token_count placeholders with halstead_volume. Python analyzer now fills function and file halstead_volume values. Pydantic models (FunctionMetric, FileMetrics) now include halstead_volume (Optional[float]). Aggregation routines (analyze_local_folder, get_folder_matrix, normalize) sum per-file halstead_volume and include it in FolderMetrics outputs, using 0.0 or None defaults where appropriate. These changes ensure Halstead volume is captured and reported end-to-end.